### PR TITLE
Persist server keys

### DIFF
--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -1,9 +1,11 @@
 class ApiException < Exception; end
 
 class Api::ServersController < Api::BaseController
+  # TODO: most probably it should be a separate service
   def activate
     if request_ip == server.ip_address
       raise ApiException, "Already activated server #{request_ip} #{server.hostname}" if server.active?
+      server.update!(activation_params)
       server.activate!
       render json: { auth_key: server.auth_key }.to_json
     else
@@ -19,5 +21,9 @@ class Api::ServersController < Api::BaseController
 
   def server
     Server.find_by(hostname: params[:hostname]) || raise(ApiException, "Server for activation not found")
+  end
+
+  def activation_params
+    params.permit(:server_crt, :client_crt, :client_key)
   end
 end

--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -1,10 +1,13 @@
-class ApiException < Exception; end
+# frozen_string_literal: true
+
+class ApiException < RuntimeError; end
 
 class Api::ServersController < Api::BaseController
   # TODO: most probably it should be a separate service
   def activate
     if request_ip == server.ip_address
       raise ApiException, "Already activated server #{request_ip} #{server.hostname}" if server.active?
+
       server.update!(activation_params)
       server.activate!
       render json: { auth_key: server.auth_key }.to_json
@@ -20,7 +23,7 @@ class Api::ServersController < Api::BaseController
   end
 
   def server
-    Server.find_by(hostname: params[:hostname]) || raise(ApiException, "Server for activation not found")
+    Server.find_by(hostname: params[:hostname]) || raise(ApiException, 'Server for activation not found')
   end
 
   def activation_params

--- a/db/migrate/20190122184018_add_pki_to_server.rb
+++ b/db/migrate/20190122184018_add_pki_to_server.rb
@@ -1,0 +1,7 @@
+class AddPkiToServer < ActiveRecord::Migration
+  def change
+    add_column :servers, :server_crt, :text
+    add_column :servers, :client_crt, :text
+    add_column :servers, :client_key, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181014150549) do
+ActiveRecord::Schema.define(version: 20190122184018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,9 @@ ActiveRecord::Schema.define(version: 20181014150549) do
     t.string   "protocol",     default: "udp"
     t.integer  "port",         default: 443
     t.string   "country_code", default: "de"
+    t.text     "server_crt"
+    t.text     "client_crt"
+    t.text     "client_key"
   end
 
   add_index "servers", ["hostname"], name: "index_servers_on_hostname", unique: true, using: :btree

--- a/spec/controllers/api/servers_controller_spec.rb
+++ b/spec/controllers/api/servers_controller_spec.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Api::ServersController do
   let!(:server) { create(:server) }
 
-  describe "POST #activate" do
-    context "hostname not present in DB" do
-      it "raises error" do
-        expect {
-          post :activate, hostname: "incorrect.domain"
-        }.to raise_error ApiException, "Server for activation not found"
+  describe 'POST #activate' do
+    context 'hostname not present in DB' do
+      it 'raises error' do
+        expect do
+          post :activate, hostname: 'incorrect.domain'
+        end.to raise_error ApiException, 'Server for activation not found'
       end
     end
 
@@ -22,17 +24,17 @@ describe Api::ServersController do
         }
       end
 
-      context "correct ip" do
+      context 'correct ip' do
         before do
           @request.env['REMOTE_ADDR'] = server.ip_address
         end
 
-        it "renders json with auth key" do
+        it 'renders json with auth key' do
           post :activate, params
           expect(response.body).to eq Hash[auth_key: server.auth_key].to_json
         end
 
-        it "returns success status" do
+        it 'returns success status' do
           post :activate, params
           expect(response.status).to eq 200
         end
@@ -40,16 +42,16 @@ describe Api::ServersController do
         it 'updates server pki fields' do
           expect { post :activate, params }
             .to change  { server.reload.server_crt }.to('server crt')
-            .and change { server.reload.client_crt }.to('client crt')
-            .and change { server.reload.client_key }.to('client key')
+                                                    .and change { server.reload.client_crt }.to('client crt')
+                                                                                            .and change { server.reload.client_key }.to('client key')
         end
       end
 
       context 'incorrect ip' do
         it 'raises error' do
-          expect {
+          expect do
             post :activate, params
-          }.to raise_error ApiException
+          end.to raise_error ApiException
         end
       end
     end


### PR DESCRIPTION
Adds an ability to receive `server.crt`, `client.crt`, `client.key` and keep them in billing.

They can be used for generating the configuration files for customers.